### PR TITLE
Added a Docker support and fixed non-backwards compatability issue with 'Network' library.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM haskell
+ADD ./ ./src
+RUN cd src && cabal update && cabal build
+WORKDIR src/dist-newstyle/build/x86_64-linux/ghc-8.8.3/imcs-2.5.0.2/x/imcs/build/imcs/
+RUN ./imcs --init
+EXPOSE 3589
+ENTRYPOINT ["./imcs"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Internet MiniChess Server
 
 Copyright &copy; 2007-2017 Bart Massey  
@@ -46,3 +47,15 @@ cause the server to exit.
 
 The `--port <n>` argument sets the server listening port;
 the current default port is, for no very good reason, 3589.
+
+
+## Running With Docker
+
+The provided `Dockerfile` can be used to run this program inside a docker container.
+You can build the image using the following command inside the root directory of this project:
+
+    docker build -t imcs .
+You can then start a container with the following command:
+
+    docker run -itd -p 3589:3589 imcs
+

--- a/imcs.cabal
+++ b/imcs.cabal
@@ -78,7 +78,7 @@ executable imcs
   
   -- Other library packages from which modules are imported.
   build-depends:       base >=4,
-                       network >=2,
+                       network ==2.*,
                        parseargs >=0.1,
                        mtl >=2.1 ,
                        random >=1,


### PR DESCRIPTION
- Added a more concrete version of the 'Network' library to the cabal file, since newer verisons do not seem to be backwards compatible.

- Added a 'Dockerfile' to the repository as well as instructions on how to use it to the 'README.md'